### PR TITLE
Firefox profile

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "foxr",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Node.js API to control Firefox",
   "keywords": "firefox, headless, remote, marionette, puppeteer, selenium",
   "homepage": "https://github.com/deepsweet/foxr",

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ type TLaunchOptions = {
 foxr.launch(options?: TLaunchOptions): Promise<Browser>
 ```
 
-* `args` – array of additional args, `['-marionette', '-safe-mode', '-no-remote']` by default
+* `args` – array of additional args. Ex: `['--profile <path-to-profile>']`. `['-marionette', '-safe-mode', '-no-remote']` by default
 * `dumpio` – print browser process stdout and stderr, `false` by default
 * `executablePath` – path to Firefox executable, required
 * `headless` – whether to run browser in headless mode, `true` by default

--- a/src/api/Foxr.ts
+++ b/src/api/Foxr.ts
@@ -114,7 +114,7 @@ class Foxr {
 
     firefoxProcess.unref()
 
-    await waitForPort(DEFAULT_HOST, DEFAULT_PORT)
+    await waitForPort(options.host || DEFAULT_HOST, options.port || DEFAULT_PORT)
 
     return this.connect(options)
   }

--- a/src/api/Foxr.ts
+++ b/src/api/Foxr.ts
@@ -104,7 +104,8 @@ class Foxr {
 
     const firefoxProcess = execa(options.executablePath, args, {
       detached: true,
-      stdio: options.dumpio ? 'inherit' : 'ignore'
+      stdio: options.dumpio ? 'inherit' : 'ignore',
+      shell: true
     })
 
     onExit(() => {


### PR DESCRIPTION
Allow running on localhost a non-default profile with a configurable port.

`execa` needs shell enabled in order to pass a relative path as param.

launch method now use port and host provided in options, instead of always using the default ones.

